### PR TITLE
all routes on spreadsheet as of 1/21/20 completed

### DIFF
--- a/db/db_interactions/auth.js
+++ b/db/db_interactions/auth.js
@@ -80,4 +80,17 @@ const setHotel = function (id, hotelId) {
     })
 }
 
-module.exports = { signup, login, setName, setEmail, setPhoneNumber, setHotel }
+const deleteUser = function (id) {
+    return new Promise ((resolve, reject) => {
+        const queryString = "DELETE FROM users WHERE id = " + [id];
+        connection.query(queryString, (err, res) => {
+            if (err) {
+                reject (err);
+            } else {
+                resolve("success");
+            }
+        })
+    })
+}
+
+module.exports = { signup, login, setName, setEmail, setPhoneNumber, setHotel, deleteUser }

--- a/db/db_interactions/availabilities.js
+++ b/db/db_interactions/availabilities.js
@@ -1,0 +1,42 @@
+const connection = require('../db');
+
+const addShift = function ( driverId, carId, hotelId, startTime, endTime) {
+    return new Promise((resolve, reject) => {
+        const queryString = "INSERT INTO availabilities (driverId, carId, hotelId, startTime, endTime) VALUES ("  + [driverId, carId, hotelId, startTime, endTime].join(", ") + ")";
+        connection.query(queryString, (err) => {
+            if (err) {
+                reject (err);
+            } else {
+                resolve("success");
+            }
+        })
+    })
+}
+
+const deleteShift = function ( id ) {
+    return new Promise((resolve, reject) => {
+        const queryString = "DELETE FROM availabilities WHERE id = " + [id]; //TODO: SET availabilityId in pickups table as a FK referencing availabilty table's id column.  Then set"delete_rule = 'CASCADE'" which will cause this deletion operation on availabilities to also delete all pickups with matching availabilityId.
+        connection.query(queryString, (err) => {
+            if (err) {
+                reject (err);
+            } else {
+                resolve("success");
+            }
+        })
+    })
+}
+
+const getShifts = function ( driverId ) {
+    return new Promise((resolve, reject) => {
+        const queryString = "SELECT * FROM availabilities WHERE driverId = " + [driverId];
+        connection.query(queryString, (err, res) => {
+            if (err) {
+                reject (err);
+            } else {
+                resolve(res);
+            }
+        })
+    })
+}
+
+module.exports = { addShift, deleteShift, getShifts }

--- a/db/db_interactions/index.js
+++ b/db/db_interactions/index.js
@@ -1,6 +1,8 @@
 const auth = require('./auth');
 const hotels = require('./hotels');
 const pickups = require('./pickups');
+const availabilities = require('./availabilities');
 const schedulingHelpers = require('./schedulingHelpers');
 
-module.exports = { auth, hotels, pickups, schedulingHelpers }
+
+module.exports = { auth, hotels, pickups, schedulingHelpers, availabilities }

--- a/db/db_interactions/pickups.js
+++ b/db/db_interactions/pickups.js
@@ -18,4 +18,17 @@ const createPickup = function (to, from, userId, hotelId, rideShare, numBags, nu
     })
 }
 
-module.exports = { createPickup }
+const deletePickup = function (id) {
+    return new Promise((resolve, reject) => {
+        const queryString = "DELETE FROM pickups WHERE id = "  + [id] ; //TODO: make sure this query also removes its id from any other pickup that has it as a ride share.
+        connection.query(queryString, (err) => {
+            if (err) {
+                reject (err);
+            } else {
+                resolve("success");
+            }
+        })
+    })
+}
+
+module.exports = { createPickup, deletePickup }

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -63,4 +63,14 @@ router.post("/api/setHotel", (req, res) => {
     })
 })
 
+router.post("/api/deleteUser", (req, res) => {
+    db.auth.deleteUser(helpers.addQuotes(req.body.id))
+    .then((val) => {
+        res.send(val)
+    })
+    .catch((err) => {
+        res.send(err)
+    })
+})
+
 module.exports = router;

--- a/routes/availabilities.js
+++ b/routes/availabilities.js
@@ -1,0 +1,35 @@
+const db = require('../db/db_interactions');
+const router = require('express').Router();
+const helpers = require('./helpers');
+
+router.post('/api/addShift', (req, res) => {
+    db.availabilities.addShift(req.body.driverId, req.body.carId, req.body.hotelId, helpers.addQuotes(req.body.startTime), helpers.addQuotes(req.body.endTime))
+    .then((val) => {
+        res.send(val);
+    })
+    .catch(err => {
+        res.send(err);
+    })
+})
+
+router.post('/api/deleteShift', (req, res) => {
+    db.availabilities.deleteShift(req.body.id)
+    .then((val) => {
+        res.send(val);
+    })
+    .catch(err => {
+        res.send(err);
+    })
+})
+
+router.get('/api/getShifts', (req, res) => {
+    db.availabilities.getShifts(req.query.driverId)
+    .then((val) => {
+        res.send(val);
+    })
+    .catch(err => {
+        res.send(err);
+    })
+})
+
+module.exports = router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -2,5 +2,6 @@ const auth = require('./auth');
 const hotels = require('./hotels')
 const pickups = require('./pickups')
 const scheduleRide = require('./scheduleRide');
+const availabilities = require('./availabilities');
 
-module.exports = { auth, hotels, pickups, scheduleRide }
+module.exports = { auth, hotels, pickups, scheduleRide, availabilities }

--- a/routes/pickups.js
+++ b/routes/pickups.js
@@ -12,4 +12,14 @@ router.post("/api/createPickup", (req, res) => {
     })
 })
 
+router.post("/api/deletePickup", (req, res) => {
+    db.pickups.deletePickup(req.body.id)
+    .then((val) => {
+        res.send(val)
+    })
+    .catch((err) => {
+        res.send(err);
+    })
+})
+
 module.exports = router;

--- a/server.js
+++ b/server.js
@@ -13,8 +13,8 @@ app.use(cors());
 app.use(express.urlencoded({ extended: true }));
 
 //routes go here
-const { auth, hotels, pickups, scheduleRide } = require('./routes');
-app.use(auth, hotels, pickups, scheduleRide);
+const { auth, hotels, pickups, scheduleRide, availabilities } = require('./routes');
+app.use(auth, hotels, pickups, scheduleRide, availabilities);
 
 app.get("/", (req, res) => {
     res.send("Drive yourself!")


### PR DESCRIPTION
-deleteShift: SET availabilityId in pickups table as a FK referencing availabilties's id column.  Then set"delete_rule = 'CASCADE'" which will cause the deletion operation  on availabilities currently implemented to also delete all pickups with matching availabilityId.

-deletePickup: not fully functioning as listed on the spreadsheet (see comments in code/spreadsheet) because I think we need some join tables to be set up to make this possible.  Wanted to confer before doing that, but the basic route/query is set up.

-Had to pass datetimes as strings to not get an error from the db.  Just noting this for consistency's sake.